### PR TITLE
Fix PHP types and remove unused code

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -3,19 +3,16 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Foundation\Application;
-use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class IndexController extends Controller
 {
     public function __invoke()
     {
-        {
-            return Inertia::render('Index', [
-                'laravelVersion' => Application::VERSION,
-                'phpVersion' => PHP_VERSION,
-                'generatedLink' => session('generatedLink')
-            ]);
-        }
+        return Inertia::render('Index', [
+            'laravelVersion' => Application::VERSION,
+            'phpVersion' => PHP_VERSION,
+            'generatedLink' => session('generatedLink')
+        ]);
     }
 }

--- a/app/Repositories/LinkRepository.php
+++ b/app/Repositories/LinkRepository.php
@@ -51,7 +51,7 @@ class LinkRepository
         });
     }
 
-    private static function calculateExpiration(string|int $expirationValue): Carbon
+    private static function calculateExpiration(string|int $expirationValue): ?Carbon
     {
         return match ((string)$expirationValue) {
             '5' => now()->addMinutes(5),


### PR DESCRIPTION
## Summary
- fix return type in `LinkRepository::calculateExpiration`
- clean up unused code and stray braces in `IndexController`

## Testing
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f6c9168c832882f731ee23f6aa7f